### PR TITLE
feat/refactor-and-tx-batching

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,3 +24,5 @@ arithmetic.workspace = true
 stark.workspace = true
 tokio = "1.44.2"
 futures = "0.3.31"
+env_logger = {version = "0.11.6",features = ["unstable-kv"]}
+log = {version = "0.4.22",features = ["kv"]}

--- a/client/src/deploy.rs
+++ b/client/src/deploy.rs
@@ -1,0 +1,57 @@
+use std::path::Path;
+
+use solana_sdk::{
+    signature::{write_keypair_file, Keypair},
+    signer::Signer,
+    transaction::Transaction,
+};
+use verifier::state::BidirectionalStackAccount;
+
+use crate::{initialize_client, setup_payer, setup_program, Config, Result};
+
+pub async fn deploy(config: &Config) -> Result<()> {
+    let client = initialize_client(config).await?;
+    let payer = if let Some(ref payer_keypair) = config.payer_keypair {
+        Keypair::from_base58_string(payer_keypair)
+    } else {
+        setup_payer(&client, config).await?
+    };
+    println!("Using payer: {}", payer.pubkey());
+
+    let program_path = Path::new("target/deploy/verifier.so");
+    let program_id = setup_program(&client, &payer, config, program_path).await?;
+    println!("Using program ID: {program_id}");
+
+    let stack_account = Keypair::new();
+    write_keypair_file(
+        &stack_account,
+        config.keypairs_dir.join("stack-account-keypair.json"),
+    )
+    .unwrap();
+    println!("Creating new account: {}", stack_account.pubkey());
+
+    let space = size_of::<BidirectionalStackAccount>();
+    println!("Account space: {space} bytes");
+
+    let create_account_ix = solana_system_interface::instruction::create_account(
+        &payer.pubkey(),
+        &stack_account.pubkey(),
+        client.get_minimum_balance_for_rent_exemption(space).await?,
+        space as u64,
+        &program_id,
+    );
+
+    let create_account_tx = Transaction::new_signed_with_payer(
+        &[create_account_ix],
+        Some(&payer.pubkey()),
+        &[&payer, &stack_account],
+        client.get_latest_blockhash().await?,
+    );
+
+    let signature = client
+        .send_and_confirm_transaction(&create_account_tx)
+        .await?;
+
+    println!("Account created successfully: {signature}");
+    Ok(())
+}

--- a/client/src/deploy.rs
+++ b/client/src/deploy.rs
@@ -8,6 +8,7 @@ use solana_sdk::{
 use verifier::state::BidirectionalStackAccount;
 
 use crate::{initialize_client, setup_payer, setup_program, Config, Result};
+use log::info;
 
 pub async fn deploy(config: &Config) -> Result<()> {
     let client = initialize_client(config).await?;
@@ -16,11 +17,11 @@ pub async fn deploy(config: &Config) -> Result<()> {
     } else {
         setup_payer(&client, config).await?
     };
-    println!("Using payer: {}", payer.pubkey());
+    info!(public_key:% = payer.pubkey(); "Using payer");
 
     let program_path = Path::new("target/deploy/verifier.so");
     let program_id = setup_program(&client, &payer, config, program_path).await?;
-    println!("Using program ID: {program_id}");
+    info!(program_id:% = program_id; "Using program");
 
     let stack_account = Keypair::new();
     write_keypair_file(
@@ -28,10 +29,10 @@ pub async fn deploy(config: &Config) -> Result<()> {
         config.keypairs_dir.join("stack-account-keypair.json"),
     )
     .unwrap();
-    println!("Creating new account: {}", stack_account.pubkey());
+    info!(public_key:% = stack_account.pubkey(); "Creating new account");
 
     let space = size_of::<BidirectionalStackAccount>();
-    println!("Account space: {space} bytes");
+    info!(size_in_bytes:% = space; "Account space");
 
     let create_account_ix = solana_system_interface::instruction::create_account(
         &payer.pubkey(),
@@ -52,6 +53,6 @@ pub async fn deploy(config: &Config) -> Result<()> {
         .send_and_confirm_transaction(&create_account_tx)
         .await?;
 
-    println!("Account created successfully: {signature}");
+    info!(signature:% = signature; "Account created successfully");
     Ok(())
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,3 +7,7 @@ pub mod utils;
 pub use config::Config;
 pub use error::{ClientError, Result};
 pub use utils::*;
+
+pub mod deploy;
+pub mod retrive_funds;
+pub mod verify;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -21,6 +21,7 @@ enum Subcommands {
 #[tokio::main]
 #[allow(clippy::result_large_err)]
 async fn main() -> client::Result<()> {
+    env_logger::Builder::from_default_env().init();
     let cli = Cli::parse();
     match cli.command {
         Subcommands::Verify(config) => verify::verify(&config).await?,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,234 +1,31 @@
-use std::path::Path;
+use clap::{Parser, Subcommand};
+use client::{deploy, retrive_funds, verify, Config};
 
-use client::{
-    initialize_client, interact_with_program_instructions, send_and_confirm_transactions,
-    setup_payer, setup_program, ClientError, Config,
-};
-use solana_sdk::{
-    compute_budget::ComputeBudgetInstruction,
-    instruction::{AccountMeta, Instruction},
-    native_token::LAMPORTS_PER_SOL,
-    signature::Keypair,
-    signer::Signer,
-    transaction::Transaction,
-};
-use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
-use stark::{
-    felt::Felt, stark_proof::VerifyPublicInput, swiftness::stark::types::cast_struct_to_slice,
-};
-use swiftness_proof_parser::{json_parser, transform::TransformTo, StarkProof as StarkProofParser};
-use utils::AccountCast;
-use utils::BidirectionalStack;
-use utils::Executable;
-use verifier::{instruction::VerifierInstruction, state::BidirectionalStackAccount};
+#[derive(Debug, Parser)]
+#[clap(about, version)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Subcommands,
+}
 
-pub const CHUNK_SIZE: usize = 1000;
+#[derive(Debug, Subcommand)]
+enum Subcommands {
+    /// Verify a proof using existing account and programs
+    Verify(Config),
+    /// Deploy a new program to the solana and create a new account
+    Deploy(Config),
+    /// Retrive funds from the solana (close the account)
+    RetriveFunds(Config),
+}
 
 #[tokio::main]
 #[allow(clippy::result_large_err)]
 async fn main() -> client::Result<()> {
-    let config = Config::parse_args();
-    let client = initialize_client(&config).await?;
-    let payer = if let Some(ref payer_keypair) = config.payer_keypair {
-        Keypair::from_base58_string(payer_keypair)
-    } else {
-        setup_payer(&client, &config).await?
-    };
-    println!("Using payer: {}", payer.pubkey());
-
-    let program_path = Path::new("target/deploy/verifier.so");
-
-    let program_id = setup_program(&client, &payer, &config, program_path).await?;
-    println!("Using program ID: {program_id}");
-    let stack_account = Keypair::new();
-
-    println!("Creating new account: {}", stack_account.pubkey());
-
-    let space = size_of::<BidirectionalStackAccount>();
-    println!("Account space: {space} bytes");
-
-    let create_account_ix = solana_system_interface::instruction::create_account(
-        &payer.pubkey(),
-        &stack_account.pubkey(),
-        client.get_minimum_balance_for_rent_exemption(space).await?,
-        space as u64,
-        &program_id,
-    );
-
-    let create_account_tx = Transaction::new_signed_with_payer(
-        &[create_account_ix],
-        Some(&payer.pubkey()),
-        &[&payer, &stack_account],
-        client.get_latest_blockhash().await?,
-    );
-
-    let signature = client
-        .send_and_confirm_transaction(&create_account_tx)
-        .await?;
-    println!("Account created successfully: {signature}");
-
-    let mut input: [u64; 2] = [0, 65536];
-    let proof_bytes = cast_struct_to_slice(&mut input);
-    let new_offset = proof_bytes.len();
-    println!("Proof bytes in kb: {:?}", proof_bytes.len() / 1024);
-    let instructions = proof_bytes
-        .chunks(CHUNK_SIZE)
-        .enumerate()
-        .map(|(i, chunk)| {
-            Instruction::new_with_borsh(
-                program_id,
-                &VerifierInstruction::SetAccountData(i * CHUNK_SIZE, chunk.to_vec()),
-                vec![AccountMeta::new(stack_account.pubkey(), false)],
-            )
-        })
-        .collect::<Vec<_>>();
-
-    println!("Instructions number: {:?}", instructions.len());
-    // std::thread::sleep(Duration::from_secs(10));
-    for (i, instruction) in instructions.iter().enumerate() {
-        let set_proof_tx = Transaction::new_signed_with_payer(
-            &[instruction.clone()],
-            Some(&payer.pubkey()),
-            &[&payer],
-            client.get_latest_blockhash().await?,
-        );
-        let set_proof_signature: solana_sdk::signature::Signature =
-            client.send_and_confirm_transaction(&set_proof_tx).await?;
-        println!("Set proof: {i}: {set_proof_signature}");
+    let cli = Cli::parse();
+    match cli.command {
+        Subcommands::Verify(config) => verify::verify(&config).await?,
+        Subcommands::Deploy(config) => deploy::deploy(&config).await?,
+        Subcommands::RetriveFunds(config) => retrive_funds::retrive_funds(&config).await?,
     }
-
-    println!("Account created successfully: {signature}");
-    println!("\nSet Proof on Solana");
-    println!("====================");
-    let input = include_str!("../../example_proof/saya.json");
-    let proof_json = serde_json::from_str::<json_parser::StarkProof>(input).unwrap();
-    let proof = StarkProofParser::try_from(proof_json).unwrap();
-
-    let mut proof_verifier = proof.transform_to();
-
-    let proof_bytes = cast_struct_to_slice(&mut proof_verifier);
-    println!("Proof bytes in kb: {:?}", proof_bytes.len() / 1024);
-    let instructions = proof_bytes
-        .chunks(CHUNK_SIZE)
-        .enumerate()
-        .map(|(i, chunk)| {
-            Instruction::new_with_borsh(
-                program_id,
-                &VerifierInstruction::SetAccountData(new_offset + (i * CHUNK_SIZE), chunk.to_vec()),
-                vec![AccountMeta::new(stack_account.pubkey(), false)],
-            )
-        })
-        .collect::<Vec<_>>();
-
-    println!("Instructions number: {:?}", instructions.len());
-    for (i, instruction) in instructions.iter().enumerate() {
-        let set_proof_tx = Transaction::new_signed_with_payer(
-            &[instruction.clone()],
-            Some(&payer.pubkey()),
-            &[&payer],
-            client.get_latest_blockhash().await?,
-        );
-        let set_proof_signature: solana_sdk::signature::Signature =
-            client.send_transaction(&set_proof_tx).await?;
-        println!("Set proof: {i}: {set_proof_signature}");
-    }
-
-    let task = VerifyPublicInput::new();
-
-    let verify_public_input_ix = Instruction::new_with_borsh(
-        program_id,
-        &VerifierInstruction::PushTask(task.to_vec_with_type_tag()),
-        vec![AccountMeta::new(stack_account.pubkey(), false)],
-    );
-
-    let signature = interact_with_program_instructions(
-        &client,
-        &payer,
-        &program_id,
-        &stack_account,
-        &[verify_public_input_ix],
-    )
-    .await?;
-    println!("Verify public input: {signature}");
-
-    let limit_instructions = ComputeBudgetInstruction::set_compute_unit_limit(800_000);
-
-    let mut account_data = client
-        .get_account_data(&stack_account.pubkey())
-        .await
-        .map_err(ClientError::SolanaClientError)?;
-    let stack = BidirectionalStackAccount::cast_mut(&mut account_data);
-    let simulation_steps = stack.simulate();
-
-    println!("Simulation steps: {simulation_steps}");
-
-    let mut transactions = Vec::new();
-    for i in 0..simulation_steps {
-        // Execute the task
-        let execute_ix = Instruction::new_with_borsh(
-            program_id,
-            &VerifierInstruction::Execute(i as u32),
-            vec![AccountMeta::new(stack_account.pubkey(), false)],
-        );
-
-        let execute_tx = Transaction::new_signed_with_payer(
-            &[limit_instructions.clone(), execute_ix],
-            Some(&payer.pubkey()),
-            &[&payer],
-            client.get_latest_blockhash().await?,
-        );
-        transactions.push(execute_tx.clone());
-    }
-    send_and_confirm_transactions(&client, &transactions).await?;
-
-    // Read and display the result
-    let mut account_data = client
-        .get_account_data(&stack_account.pubkey())
-        .await
-        .map_err(ClientError::SolanaClientError)?;
-    let stack = BidirectionalStackAccount::cast_mut(&mut account_data);
-    let result_program_hash = Felt::from_bytes_be_slice(stack.borrow_front());
-    stack.pop_front();
-    let result_output_hash = Felt::from_bytes_be_slice(stack.borrow_front());
-    stack.pop_front();
-    println!("\nProgram Hash: {result_program_hash:?}");
-    println!("Output Hash: {result_output_hash:?}");
-    println!("Stack front index: {}", stack.front_index);
-    println!("Stack back index: {}", stack.back_index);
-
-    println!("\nHash Public Inputs successfully executed on Solana!");
-
-    println!("Closing account");
-
-    let balance = client.get_balance(&payer.pubkey()).await?;
-    let balance_sol = balance as f64 / LAMPORTS_PER_SOL as f64;
-    println!("Balance: {balance_sol} SOL");
-
-    let close_account_ix = Instruction::new_with_borsh(
-        program_id,
-        &VerifierInstruction::Close,
-        vec![
-            AccountMeta::new(stack_account.pubkey(), true),
-            AccountMeta::new(payer.pubkey(), false),
-            AccountMeta::new(SYSTEM_PROGRAM_ID, false),
-        ],
-    );
-
-    let close_account_tx = Transaction::new_signed_with_payer(
-        &[close_account_ix],
-        Some(&payer.pubkey()),
-        &[&stack_account, &payer],
-        client.get_latest_blockhash().await?,
-    );
-    let close_account_signature = client
-        .send_and_confirm_transaction(&close_account_tx)
-        .await?;
-
-    println!("Account closed successfully: {close_account_signature}");
-
-    let balance = client.get_balance(&payer.pubkey()).await?;
-    let balance_sol = balance as f64 / LAMPORTS_PER_SOL as f64;
-    println!("Balance: {balance_sol} SOL after closing");
-
     Ok(())
 }

--- a/client/src/retrive_funds.rs
+++ b/client/src/retrive_funds.rs
@@ -1,0 +1,62 @@
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    native_token::LAMPORTS_PER_SOL,
+    signature::Keypair,
+    signer::{EncodableKey, Signer},
+    transaction::Transaction,
+};
+use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
+use verifier::instruction::VerifierInstruction;
+
+use crate::{initialize_client, setup_payer, Config, Result};
+
+#[allow(clippy::result_large_err)]
+pub async fn retrive_funds(config: &Config) -> Result<()> {
+    let client = initialize_client(config).await?;
+    let payer = if let Some(ref payer_keypair) = config.payer_keypair {
+        Keypair::from_base58_string(payer_keypair)
+    } else {
+        setup_payer(&client, config).await?
+    };
+    println!("Using payer: {}", payer.pubkey());
+
+    let program_keypair = Keypair::read_from_file("keypairs/verifier-keypair.json").unwrap();
+    let program_id = program_keypair.pubkey();
+
+    println!("Using program ID: {program_id}");
+    let stack_account = Keypair::read_from_file("keypairs/stack-account-keypair.json").unwrap();
+
+    println!("Closing account");
+
+    let balance = client.get_balance(&payer.pubkey()).await?;
+    let balance_sol = balance as f64 / LAMPORTS_PER_SOL as f64;
+    println!("Balance: {balance_sol} SOL");
+
+    let close_account_ix = Instruction::new_with_borsh(
+        program_id,
+        &VerifierInstruction::Close,
+        vec![
+            AccountMeta::new(stack_account.pubkey(), true),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new(SYSTEM_PROGRAM_ID, false),
+        ],
+    );
+
+    let close_account_tx = Transaction::new_signed_with_payer(
+        &[close_account_ix],
+        Some(&payer.pubkey()),
+        &[&stack_account, &payer],
+        client.get_latest_blockhash().await?,
+    );
+    let close_account_signature = client
+        .send_and_confirm_transaction(&close_account_tx)
+        .await?;
+
+    println!("Account closed successfully: {close_account_signature}");
+
+    let balance = client.get_balance(&payer.pubkey()).await?;
+    let balance_sol = balance as f64 / LAMPORTS_PER_SOL as f64;
+    println!("Balance: {balance_sol} SOL after closing");
+
+    Ok(())
+}

--- a/client/src/retrive_funds.rs
+++ b/client/src/retrive_funds.rs
@@ -9,7 +9,7 @@ use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
 use verifier::instruction::VerifierInstruction;
 
 use crate::{initialize_client, setup_payer, Config, Result};
-
+use log::info;
 #[allow(clippy::result_large_err)]
 pub async fn retrive_funds(config: &Config) -> Result<()> {
     let client = initialize_client(config).await?;
@@ -18,19 +18,19 @@ pub async fn retrive_funds(config: &Config) -> Result<()> {
     } else {
         setup_payer(&client, config).await?
     };
-    println!("Using payer: {}", payer.pubkey());
+    info!(public_key:% = payer.pubkey(); "Using payer");
 
     let program_keypair = Keypair::read_from_file("keypairs/verifier-keypair.json").unwrap();
     let program_id = program_keypair.pubkey();
 
-    println!("Using program ID: {program_id}");
+    info!(program_id:% = program_id; "Using program");
     let stack_account = Keypair::read_from_file("keypairs/stack-account-keypair.json").unwrap();
 
-    println!("Closing account");
+    info!("Closing account");
 
     let balance = client.get_balance(&payer.pubkey()).await?;
     let balance_sol = balance as f64 / LAMPORTS_PER_SOL as f64;
-    println!("Balance: {balance_sol} SOL");
+    info!(balance_sol:% = balance_sol; "Balance");
 
     let close_account_ix = Instruction::new_with_borsh(
         program_id,
@@ -52,11 +52,11 @@ pub async fn retrive_funds(config: &Config) -> Result<()> {
         .send_and_confirm_transaction(&close_account_tx)
         .await?;
 
-    println!("Account closed successfully: {close_account_signature}");
+    info!(signature:% = close_account_signature; "Account closed successfully");
 
     let balance = client.get_balance(&payer.pubkey()).await?;
     let balance_sol = balance as f64 / LAMPORTS_PER_SOL as f64;
-    println!("Balance: {balance_sol} SOL after closing");
+    info!(balance_sol:% = balance_sol; "Balance after closing");
 
     Ok(())
 }

--- a/client/src/verify.rs
+++ b/client/src/verify.rs
@@ -1,0 +1,136 @@
+use crate::{
+    initialize_client, interact_with_program_instructions, send_and_confirm_with_limit,
+    setup_payer, ClientError,
+};
+use crate::{read_keypair_file, Config, Result};
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    signature::Keypair,
+    signer::Signer,
+};
+use stark::{
+    felt::Felt, stark_proof::VerifyPublicInput, swiftness::stark::types::cast_struct_to_slice,
+};
+use swiftness_proof_parser::{json_parser, transform::TransformTo, StarkProof as StarkProofParser};
+use utils::AccountCast;
+use utils::BidirectionalStack;
+use utils::Executable;
+use verifier::{instruction::VerifierInstruction, state::BidirectionalStackAccount};
+
+pub const CHUNK_SIZE: usize = 900;
+
+pub async fn verify(config: &Config) -> Result<()> {
+    let client = initialize_client(config).await?;
+    let payer = if let Some(ref payer_keypair) = config.payer_keypair {
+        Keypair::from_base58_string(payer_keypair)
+    } else {
+        setup_payer(&client, config).await?
+    };
+    println!("Using payer: {}", payer.pubkey());
+
+    let program_keypair = read_keypair_file("keypairs/verifier-keypair.json").unwrap();
+    let program_id = program_keypair.pubkey();
+    println!("Using program ID: {program_id}");
+
+    let stack_account = read_keypair_file("keypairs/stack-account-keypair.json").unwrap();
+    println!("Using stack account: {}", stack_account.pubkey());
+
+    let time = std::time::Instant::now();
+    let mut input: [u64; 2] = [0, 65536];
+    let proof_bytes = cast_struct_to_slice(&mut input);
+    let new_offset = proof_bytes.len();
+    let stack_set_instructions = proof_bytes
+        .chunks(CHUNK_SIZE)
+        .enumerate()
+        .map(|(i, chunk)| {
+            Instruction::new_with_borsh(
+                program_id,
+                &VerifierInstruction::SetAccountData(i * CHUNK_SIZE, chunk.to_vec()),
+                vec![AccountMeta::new(stack_account.pubkey(), false)],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let input = include_str!("../../example_proof/saya.json");
+    let proof_json = serde_json::from_str::<json_parser::StarkProof>(input).unwrap();
+    let proof = StarkProofParser::try_from(proof_json).unwrap();
+
+    let mut proof_verifier = proof.transform_to();
+    let proof_bytes = cast_struct_to_slice(&mut proof_verifier);
+
+    println!("Proof bytes in kb: {:?}", proof_bytes.len() / 1024);
+    let mut proof_set_instructions = proof_bytes
+        .chunks(CHUNK_SIZE)
+        .enumerate()
+        .map(|(i, chunk)| {
+            Instruction::new_with_borsh(
+                program_id,
+                &VerifierInstruction::SetAccountData(new_offset + (i * CHUNK_SIZE), chunk.to_vec()),
+                vec![AccountMeta::new(stack_account.pubkey(), false)],
+            )
+        })
+        .collect::<Vec<_>>();
+    proof_set_instructions.extend(stack_set_instructions);
+    println!("Instructions number: {:?}", proof_set_instructions.len());
+    send_and_confirm_with_limit(&client, &proof_set_instructions, &payer, 1_000).await?;
+    println!("Time taken to set proof: {:?}", time.elapsed());
+    let time2 = std::time::Instant::now();
+    let task = VerifyPublicInput::new();
+
+    let verify_public_input_ix = Instruction::new_with_borsh(
+        program_id,
+        &VerifierInstruction::PushTask(task.to_vec_with_type_tag()),
+        vec![AccountMeta::new(stack_account.pubkey(), false)],
+    );
+
+    let signature = interact_with_program_instructions(
+        &client,
+        &payer,
+        &program_id,
+        &stack_account,
+        &[verify_public_input_ix],
+    )
+    .await?;
+    println!("Verify public input: {signature}");
+
+    let mut account_data = client
+        .get_account_data(&stack_account.pubkey())
+        .await
+        .map_err(ClientError::SolanaClientError)?;
+    let stack = BidirectionalStackAccount::cast_mut(&mut account_data);
+    let simulation_steps = stack.simulate();
+
+    println!("Simulation steps: {simulation_steps}");
+
+    let mut instructions = vec![];
+    for i in 0..simulation_steps {
+        // Execute the task
+        let execute_ix = Instruction::new_with_borsh(
+            program_id,
+            &VerifierInstruction::Execute(i as u32),
+            vec![AccountMeta::new(stack_account.pubkey(), false)],
+        );
+        instructions.push(execute_ix);
+    }
+
+    send_and_confirm_with_limit(&client, &instructions, &payer, 500_000).await?;
+
+    println!("Time taken to execute: {:?}", time2.elapsed());
+    // Read and display the result
+    let mut account_data = client
+        .get_account_data(&stack_account.pubkey())
+        .await
+        .map_err(ClientError::SolanaClientError)?;
+    let stack = BidirectionalStackAccount::cast_mut(&mut account_data);
+    let result_program_hash = Felt::from_bytes_be_slice(stack.borrow_front());
+    stack.pop_front();
+    let result_output_hash = Felt::from_bytes_be_slice(stack.borrow_front());
+    stack.pop_front();
+    println!("\nProgram Hash: {result_program_hash:?}");
+    println!("Output Hash: {result_output_hash:?}");
+    println!("Stack front index: {}", stack.front_index);
+    println!("Stack back index: {}", stack.back_index);
+
+    println!("\nHash Public Inputs successfully executed on Solana!");
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces a new approach to sending transactions. We now create instructions and send them in batches of 20 transactions each, handling the sending and confirmation asynchronously.

We also refactored the main file by splitting it into three separate modules, each with a single responsibility:

1. **Deployment** – responsible for deploying the program and initializing the stack account in `deploy.rs`
2. **Proof setup and verification** – handles setting the proof and verifying it in `verify.rs`.
3. **Cleanup** – clears the data and closes accounts, ensuring that rent is refunded in `retrive_funds.rs`.
